### PR TITLE
Pagination

### DIFF
--- a/lib/tableau_ruby.rb
+++ b/lib/tableau_ruby.rb
@@ -3,8 +3,9 @@ $:.unshift File.dirname(__FILE__)
 require 'nokogiri'
 require 'faraday'
 
-require 'tableau_ruby/util/configuration'
-require 'tableau_ruby/util/permissions'
+Dir[File.dirname(__FILE__) + '/tableau_ruby/util/*.rb'].each do |file|
+  require file
+end
 
 Dir[File.dirname(__FILE__) + '/tableau_ruby/*.rb'].each do |file|
   require file

--- a/lib/tableau_ruby/users.rb
+++ b/lib/tableau_ruby/users.rb
@@ -74,11 +74,17 @@ module Tableau
     end
 
     def find_by(params={})
-      params.update({page_size: 1000})
+      page = 1
+      params.update({page_size: 1000, page_number: page})
 
-      #BUG: if you have more than 1000 users, you wont find your users
-      #needs pagination support
       all_users = all(params)[:users]
+      num_returned = all_users.size
+      while num_returned > 0
+        page += 1
+        new_records = all(params.update(page_number: page))[:users]
+        all_users.concat(new_records)
+        num_returned = new_records.size
+      end
 
       if params[:id]
         return all_users.select {|u| u[:id] == params[:id] }.first

--- a/lib/tableau_ruby/users.rb
+++ b/lib/tableau_ruby/users.rb
@@ -1,5 +1,6 @@
 module Tableau
   class Users
+    include Util::Pagination
 
     attr_reader :workbooks
 
@@ -82,18 +83,7 @@ module Tableau
     end
     
     def all(options={})
-      page = 1
-      options.update({page_size: 1000, page_number: page})
-
-      response = get(options)
-      data = response
-      while data[:users].size < response[:pagination][:total_available].to_i
-        page += 1
-        response = get(options.update(page_number: page))
-        data[:users].concat(response[:users])
-      end
-      data.delete(:pagination)
-      data
+      paginate_over_all_records(:users, options)
     end
 
     def find_by(params={})

--- a/lib/tableau_ruby/util/pagination.rb
+++ b/lib/tableau_ruby/util/pagination.rb
@@ -1,0 +1,20 @@
+module Tableau
+  module Util
+    module Pagination
+      def paginate_over_all_records(resource, options)
+        page = 1
+        options.update({page_size: 1000, page_number: page})
+
+        response = get(options)
+        data = response
+        while data[resource].size < response[:pagination][:total_available].to_i
+          page += 1
+          response = get(options.update(page_number: page))
+          data[resource].concat(response[resource])
+        end
+        data.delete(:pagination)
+        data
+      end
+    end
+  end
+end

--- a/lib/tableau_ruby/version.rb
+++ b/lib/tableau_ruby/version.rb
@@ -1,5 +1,5 @@
 module TableauRuby
-  VERSION = '0.3.6' unless defined?(self::VERSION)
+  VERSION = '0.3.7' unless defined?(self::VERSION)
 
   def self.version
     VERSION

--- a/lib/tableau_ruby/workbook.rb
+++ b/lib/tableau_ruby/workbook.rb
@@ -233,15 +233,17 @@ BODY
     private
 
     def include_views(params)
+      views = []
+      
       resp = @client.conn.get("/api/2.0/sites/#{params[:site_id]}/workbooks/#{params[:id]}/views") do |req|
         req.headers['X-Tableau-Auth'] = @client.token if @client.token
       end
 
       Nokogiri::XML(resp.body).css("view").each do |view|
-        (@views ||= []) << {id: view['id'], name: view['name'], contentUrl: view[:contentUrl]}
+        views << {id: view['id'], name: view['name'], contentUrl: view[:contentUrl]}
       end
 
-      @views
+      views
     end
 
   end

--- a/lib/tableau_ruby/workbook.rb
+++ b/lib/tableau_ruby/workbook.rb
@@ -237,8 +237,8 @@ BODY
         req.headers['X-Tableau-Auth'] = @client.token if @client.token
       end
 
-      Nokogiri::XML(resp.body).css("view").each do |v|
-        (@views ||= []) << {id: v['id'], name: v['name']}
+      Nokogiri::XML(resp.body).css("view").each do |view|
+        (@views ||= []) << {id: view['id'], name: view['name'], contentUrl: view[:contentUrl]}
       end
 
       @views

--- a/lib/tableau_ruby/workbook.rb
+++ b/lib/tableau_ruby/workbook.rb
@@ -101,7 +101,7 @@ BODY
       end
 
       doc.css("workbook").each do |w|
-        workbook = {id: w["id"], name: w["name"]}
+        workbook = {id: w["id"], name: w["name"], updated_at: w["updatedAt"]}
 
         if options[:include_images]
           resp = @client.conn.get("/api/2.0/sites/#{@client.site_id}/workbooks/#{w['id']}/previewImage") do |req|
@@ -240,7 +240,7 @@ BODY
       end
 
       Nokogiri::XML(resp.body).css("view").each do |view|
-        views << {id: view['id'], name: view['name'], contentUrl: view[:contentUrl]}
+        views << {id: view['id'], name: view['name'], content_url: view[:contentUrl]}
       end
 
       views

--- a/lib/tableau_ruby/workbook.rb
+++ b/lib/tableau_ruby/workbook.rb
@@ -4,6 +4,7 @@ require 'securerandom'
 module Tableau
   class Workbook
     include Util::Permissions
+    include Util::Pagination
 
     def initialize(client)
       @client = client
@@ -71,11 +72,20 @@ BODY
         }
       end.first
     end
-
+    
     def all(params={})
       return { error: "user_id is missing." } if params[:user_id].nil? || params[:user_id].empty?
+      
+      paginate_over_all_records(:workbooks, params)
+    end
 
-      resp = @client.conn.get "/api/2.0/sites/#{@client.site_id}/users/#{params[:user_id]}/workbooks?pageSize=1000" do |req|
+    def get(options={})
+      return { error: "user_id is missing." } if options[:user_id].nil? || options[:user_id].empty?
+      
+      params = {pageSize: options[:page_size] || ''}
+      params.merge!(pageNumber: options[:page_number]) if options[:page_number]
+
+      resp = @client.conn.get "/api/2.0/sites/#{@client.site_id}/users/#{options[:user_id]}/workbooks", params do |req|
         req.params['getThumbnails'] = params[:include_images] if params[:include_images]
         req.params['isOwner'] = params[:is_owner] || false
         req.headers['X-Tableau-Auth'] = @client.token if @client.token
@@ -93,7 +103,7 @@ BODY
       doc.css("workbook").each do |w|
         workbook = {id: w["id"], name: w["name"]}
 
-        if params[:include_images]
+        if options[:include_images]
           resp = @client.conn.get("/api/2.0/sites/#{@client.site_id}/workbooks/#{w['id']}/previewImage") do |req|
             req.headers['X-Tableau-Auth'] = @client.token if @client.token
           end
@@ -109,7 +119,7 @@ BODY
           (workbook[:tags] ||=[]) << t['id']
         end
 
-        if params[:include_views]
+        if options[:include_views]
           workbook[:views] = include_views(site_id: @client.site_id, id: w['id'])
         end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'pry'
 require 'tableau_ruby'
 require 'mocha/setup'
 require 'vcr'
+require 'byebug'
 
 VCR.configure do |config|
   config.cassette_library_dir = "test/vcr_cassettes"

--- a/test/test_user.rb
+++ b/test/test_user.rb
@@ -11,7 +11,7 @@ class TestUsers < TableauTest
 
   def test_user_listing_with_page_size
     VCR.use_cassette("tableau_user_list", :erb => true) do
-      all_users = @client.users.all(page_size: 10)
+      all_users = @client.users.get(page_size: 10)
       assert all_users[:users].is_a? Array
       assert all_users[:users].size() > 0
     end
@@ -19,7 +19,7 @@ class TestUsers < TableauTest
 
   def test_user_listing_with_page_size_and_page_number
     VCR.use_cassette("tableau_user_list", :erb => true) do
-      all_users = @client.users.all(page_size: 10, page_number: 2)
+      all_users = @client.users.get(page_size: 10, page_number: 2)
       assert all_users[:users].is_a? Array
       assert all_users[:users].size() > 0
     end

--- a/test/test_user.rb
+++ b/test/test_user.rb
@@ -11,13 +11,21 @@ class TestUsers < TableauTest
 
   def test_user_listing_with_page_size
     VCR.use_cassette("tableau_user_list", :erb => true) do
-      all_users = @client.users.get(page_size: 10)
+      all_users = @client.users.all(page_size: 10)
       assert all_users[:users].is_a? Array
       assert all_users[:users].size() > 0
     end
   end
 
   def test_user_listing_with_page_size_and_page_number
+    VCR.use_cassette("tableau_user_list", :erb => true) do
+      all_users = @client.users.all(page_size: 10, page_number: 2)
+      assert all_users[:users].is_a? Array
+      assert all_users[:users].size() > 0
+    end
+  end
+  
+  def test_user_generic_get
     VCR.use_cassette("tableau_user_list", :erb => true) do
       all_users = @client.users.get(page_size: 10, page_number: 2)
       assert all_users[:users].is_a? Array

--- a/test/test_workbook.rb
+++ b/test/test_workbook.rb
@@ -16,6 +16,14 @@ class TestWorkbook < TableauTest
       assert workbook[:id]
     end
   end
+  
+  def test_workbook_generic_get
+    VCR.use_cassette("tableau_workbook_list", :erb => true) do
+      workbooks = @client.workbooks.get(user_id: @admin_user[:id], page_size: 1000, page_number: 1)
+      assert workbooks[:workbooks].count > 0
+      assert workbooks.keys() == [:workbooks, :pagination]
+    end
+  end
 
   def test_workbook_include_views
     VCR.use_cassette("tableau_workbook_views", :erb => true) do

--- a/test/test_workbook.rb
+++ b/test/test_workbook.rb
@@ -5,7 +5,7 @@ class TestWorkbook < TableauTest
     VCR.use_cassette("tableau_workbook_list", :erb => true) do
       workbooks = @client.workbooks.all(user_id: @admin_user[:id])
       assert workbooks[:workbooks].count > 0
-      assert workbooks[:pagination].keys() == [:page_number, :page_size, :total_available]
+      assert workbooks.keys() == [:workbooks]
     end
   end
 

--- a/test/vcr_cassettes/tableau_setup.yml
+++ b/test/vcr_cassettes/tableau_setup.yml
@@ -184,7 +184,7 @@ http_interactions:
   recorded_at: Wed, 02 Sep 2015 16:34:19 GMT
 - request:
     method: get
-    uri: <%=ENV['TABLEAU_URL']%>/api/2.0/sites/<%=ENV['TABLEAU_DEFAULT_SITE']%>/users?pageSize=1000
+    uri: <%=ENV['TABLEAU_URL']%>/api/2.0/sites/<%=ENV['TABLEAU_DEFAULT_SITE']%>/users?pageNumber=1&pageSize=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -235,7 +235,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <tsResponse xmlns="http://tableausoftware.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableausoftware.com/api http://tableausoftware.com/api/ts-api-2.0.xsd">
-          <pagination pageNumber="1" pageSize="1000" totalAvailable="15"/>
+          <pagination pageNumber="1" pageSize="1000" totalAvailable="1"/>
           <users>
             <user id="cf68994e-29c8-4f41-bf6c-398e3666131e" name="<%=ENV['TABLEAU_ADMIN_USER']%>" siteRole="ServerAdministrator" externalAuthUserId="" lastLogin="2015-09-02T16:34:20Z"/>
           </users>

--- a/test/vcr_cassettes/tableau_user_find.yml
+++ b/test/vcr_cassettes/tableau_user_find.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: <%=ENV['TABLEAU_URL']%>/api/2.0/sites/<%=ENV['TABLEAU_DEFAULT_SITE']%>/users?pageSize=1000
+    uri: <%=ENV['TABLEAU_URL']%>/api/2.0/sites/<%=ENV['TABLEAU_DEFAULT_SITE']%>/users?pageNumber=1&pageSize=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -53,7 +53,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <tsResponse xmlns="http://tableausoftware.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableausoftware.com/api http://tableausoftware.com/api/ts-api-2.0.xsd">
-          <pagination pageNumber="1" pageSize="1000" totalAvailable="15"/>
+          <pagination pageNumber="1" pageSize="1000" totalAvailable="1"/>
           <users>
             <user id="cf68994e-29c8-4f41-bf6c-398e3666131e" name="<%=ENV['TABLEAU_ADMIN_USER']%>" siteRole="ServerAdministrator" externalAuthUserId="" lastLogin="2015-09-02T16:34:20Z"/>
           </users>

--- a/test/vcr_cassettes/tableau_user_find_name.yml
+++ b/test/vcr_cassettes/tableau_user_find_name.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: <%=ENV['TABLEAU_URL']%>/api/2.0/sites/<%=ENV['TABLEAU_DEFAULT_SITE']%>/users?pageSize=1000
+    uri: <%=ENV['TABLEAU_URL']%>/api/2.0/sites/<%=ENV['TABLEAU_DEFAULT_SITE']%>/users?pageNumber=1&pageSize=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -53,7 +53,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <tsResponse xmlns="http://tableausoftware.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableausoftware.com/api http://tableausoftware.com/api/ts-api-2.0.xsd">
-          <pagination pageNumber="1" pageSize="1000" totalAvailable="15"/>
+          <pagination pageNumber="1" pageSize="1000" totalAvailable="1"/>
           <users>
             <user id="cf68994e-29c8-4f41-bf6c-398e3666131e" name="<%=ENV['TABLEAU_ADMIN_USER']%>" siteRole="ServerAdministrator" externalAuthUserId="" lastLogin="2015-09-02T16:34:20Z"/>
           </users>

--- a/test/vcr_cassettes/tableau_user_list.yml
+++ b/test/vcr_cassettes/tableau_user_list.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: <%=ENV['TABLEAU_URL']%>/api/2.0/sites/<%=ENV['TABLEAU_DEFAULT_SITE']%>/users?pageSize=
+    uri: <%=ENV['TABLEAU_URL']%>/api/2.0/sites/<%=ENV['TABLEAU_DEFAULT_SITE']%>/users?pageNumber=1&pageSize=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -53,7 +53,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <tsResponse xmlns="http://tableausoftware.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableausoftware.com/api http://tableausoftware.com/api/ts-api-2.0.xsd">
-          <pagination pageNumber="1" pageSize="100" totalAvailable="15"/>
+          <pagination pageNumber="1" pageSize="1000" totalAvailable="1"/>
           <users>
             <user id="cf68994e-29c8-4f41-bf6c-398e3666131e" name="<%=ENV['TABLEAU_ADMIN_USER']%>" siteRole="ServerAdministrator" externalAuthUserId="" lastLogin="2015-09-02T16:34:20Z"/>
           </users>
@@ -113,7 +113,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <tsResponse xmlns="http://tableausoftware.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableausoftware.com/api http://tableausoftware.com/api/ts-api-2.0.xsd">
-          <pagination pageNumber="1" pageSize="10" totalAvailable="15"/>
+          <pagination pageNumber="1" pageSize="1000" totalAvailable="1"/>
           <users>
             <user id="cf68994e-29c8-4f41-bf6c-398e3666131e" name="<%=ENV['TABLEAU_ADMIN_USER']%>" siteRole="ServerAdministrator" externalAuthUserId="" lastLogin="2015-09-02T16:34:20Z"/>
           </users>

--- a/test/vcr_cassettes/tableau_workbook_find.yml
+++ b/test/vcr_cassettes/tableau_workbook_find.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: <%=ENV['TABLEAU_URL']%>/api/2.0/sites/<%=ENV['TABLEAU_DEFAULT_SITE']%>/users/cf68994e-29c8-4f41-bf6c-398e3666131e/workbooks?isOwner=false&pageSize=1000
+    uri: <%=ENV['TABLEAU_URL']%>/api/2.0/sites/<%=ENV['TABLEAU_DEFAULT_SITE']%>/users/cf68994e-29c8-4f41-bf6c-398e3666131e/workbooks?isOwner=false&pageNumber=1&pageSize=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -53,7 +53,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <tsResponse xmlns="http://tableausoftware.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableausoftware.com/api http://tableausoftware.com/api/ts-api-2.0.xsd">
-          <pagination pageNumber="1" pageSize="1000" totalAvailable="21"/>
+          <pagination pageNumber="1" pageSize="1000" totalAvailable="3"/>
           <workbooks>
             <workbook id="4d7e46a3-eaa0-4e61-b949-7b3422c835ee" name="Tableau Tests" contentUrl="TableauTests">
               <project id="972bcf8c-d7ce-11e3-ac00-0fa50cfedda9" name="default"/>

--- a/test/vcr_cassettes/tableau_workbook_list.yml
+++ b/test/vcr_cassettes/tableau_workbook_list.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: <%=ENV['TABLEAU_URL']%>/api/2.0/sites/<%=ENV['TABLEAU_DEFAULT_SITE']%>/users/cf68994e-29c8-4f41-bf6c-398e3666131e/workbooks?isOwner=false&pageSize=1000
+    uri: <%=ENV['TABLEAU_URL']%>/api/2.0/sites/<%=ENV['TABLEAU_DEFAULT_SITE']%>/users/cf68994e-29c8-4f41-bf6c-398e3666131e/workbooks?isOwner=false&pageNumber=1&pageSize=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -53,7 +53,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <tsResponse xmlns="http://tableausoftware.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableausoftware.com/api http://tableausoftware.com/api/ts-api-2.0.xsd">
-          <pagination pageNumber="1" pageSize="1000" totalAvailable="21"/>
+          <pagination pageNumber="1" pageSize="1000" totalAvailable="3"/>
           <workbooks>
             <workbook id="4d7e46a3-eaa0-4e61-b949-7b3422c835ee" name="Tableau Tests" contentUrl="TableauTests">
               <project id="972bcf8c-d7ce-11e3-ac00-0fa50cfedda9" name="default"/>

--- a/test/vcr_cassettes/tableau_workbook_views.yml
+++ b/test/vcr_cassettes/tableau_workbook_views.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: <%=ENV['TABLEAU_URL']%>/api/2.0/sites/<%=ENV['TABLEAU_DEFAULT_SITE']%>/users/cf68994e-29c8-4f41-bf6c-398e3666131e/workbooks?isOwner=false&pageSize=1000
+    uri: <%=ENV['TABLEAU_URL']%>/api/2.0/sites/<%=ENV['TABLEAU_DEFAULT_SITE']%>/users/cf68994e-29c8-4f41-bf6c-398e3666131e/workbooks?isOwner=false&pageNumber=1&pageSize=1000
     body:
       encoding: US-ASCII
       string: ''
@@ -53,7 +53,7 @@ http_interactions:
       string: |
         <?xml version="1.0" encoding="UTF-8"?>
         <tsResponse xmlns="http://tableausoftware.com/api" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableausoftware.com/api http://tableausoftware.com/api/ts-api-2.0.xsd">
-          <pagination pageNumber="1" pageSize="1000" totalAvailable="21"/>
+          <pagination pageNumber="1" pageSize="1000" totalAvailable="3"/>
           <workbooks>
             <workbook id="4d7e46a3-eaa0-4e61-b949-7b3422c835ee" name="Tableau Tests" contentUrl="TableauTests">
               <project id="972bcf8c-d7ce-11e3-ac00-0fa50cfedda9" name="default"/>


### PR DESCRIPTION
Implements pagination over users and workbooks. Currently the `find_by` method for users has a bug in it if you have more than 1000 users on Tableau Server. Similarly, the `all` method for Workbooks would only return the first 1000 objects. Since we have thousands of users and workbooks, I thought I'd fix upstream so I don't have to implement pagination in the Data Portal.

Includes a new Pagination helper that can be used across objects to actually retrieve all results. It's only implemented in Workbooks and Users so far.

Also:
- bumps the version number
- fixes a nasty caching bug where a workbook's views would get cached in between calls, returning an ever-growing set of workbooks with each call

@jduff @JackMc for review

Tests pass, 🎩 -ed
