### PR TITLE
Add user update method and allow create user options to set role 

### DIFF
--- a/lib/tableau_ruby/users.rb
+++ b/lib/tableau_ruby/users.rb
@@ -35,6 +35,28 @@ module Tableau
       end
     end
 
+    def update(options)
+      site_id = options[:site_id] || @client.site_id
+
+      return { error: "user id is missing." } unless options[:user_id]
+
+      builder = Nokogiri::XML::Builder.new do |xml|
+        xml.tsRequest do
+          xml.user(
+            fullName: options[:fullName],
+            email: options[:email]
+          )
+        end
+      end
+  
+      resp = @client.conn.put "/api/2.0/sites/#{site_id}/users/#{options[:user_id]}" do |req|
+        req.body = builder.to_xml
+        req.headers['X-Tableau-Auth'] = @client.token if @client.token
+      end
+
+      return resp.status
+    end
+
     def delete(options)
       site_id = options[:site_id] || @client.site_id
 
@@ -82,7 +104,7 @@ module Tableau
       end
       data
     end
-    
+
     def all(options={})
       paginate_over_all_records(:users, options)
     end

--- a/lib/tableau_ruby/users.rb
+++ b/lib/tableau_ruby/users.rb
@@ -10,6 +10,7 @@ module Tableau
 
     def create(options)
       site_id = options[:site_id] || @client.site_id
+      site_role = options[:siteRole] || "Interactor"
 
       return { error: "name is missing." } unless options[:name]
 
@@ -17,7 +18,7 @@ module Tableau
         xml.tsRequest do
           xml.user(
             name: options[:name],
-            siteRole: "Interactor"
+            siteRole: site_role
           )
         end
       end

--- a/lib/tableau_ruby/users.rb
+++ b/lib/tableau_ruby/users.rb
@@ -39,17 +39,17 @@ module Tableau
       site_id = options[:site_id] || @client.site_id
 
       return { error: "user id is missing." } unless options[:user_id]
+      user_id = options[:user_id]
+
+      options.delete(:user_id)
 
       builder = Nokogiri::XML::Builder.new do |xml|
         xml.tsRequest do
-          xml.user(
-            fullName: options[:fullName],
-            email: options[:email]
-          )
+          xml.user(options)
         end
       end
   
-      resp = @client.conn.put "/api/2.0/sites/#{site_id}/users/#{options[:user_id]}" do |req|
+      resp = @client.conn.put "/api/2.0/sites/#{site_id}/users/#{user_id}" do |req|
         req.body = builder.to_xml
         req.headers['X-Tableau-Auth'] = @client.token if @client.token
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ require 'byebug'
 
 VCR.configure do |config|
   config.cassette_library_dir = "test/vcr_cassettes"
-  config.hook_into :webmock
+  config.hook_into :faraday
 end
 
 class TableauTest < Minitest::Test

--- a/test/test_user.rb
+++ b/test/test_user.rb
@@ -54,6 +54,13 @@ class TestUsers < TableauTest
       assert_equal "93796309-005f-480b-9b30-fbfb717b35bd", user_id
     end
   end
+
+  def test_user_update
+    VCR.use_cassette("tableau_user_update", :erb => true) do
+      status = @client.users.update({user_id: "1e0f9403-96c7-41ee-b2ab-e464c82e9451", fullName: "Yolo Swag", email: "yolo.swag@shopify.com"})
+      assert_equal 200, status
+    end
+  end
   
   def test_user_delete
     VCR.use_cassette("tableau_user_delete", :erb => true) do

--- a/test/vcr_cassettes/tableau_user_update.yml
+++ b/test/vcr_cassettes/tableau_user_update.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: <%=ENV['TABLEAU_URL']%>/api/2.0/sites/<%=ENV['TABLEAU_DEFAULT_SITE']%>/users/1e0f9403-96c7-41ee-b2ab-e464c82e9451
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <?xml version="1.0"?>
+        <tsRequest>
+          <user fullName="Yolo Swag" email="yolo.swag@shopify.com"/>
+        </tsRequest>
+    headers:
+      Content-Type:
+      - application/xml
+      User-Agent:
+      - Faraday v0.13.1
+      X-Tableau-Auth:
+      - b76cf89c9c1e4616fc388d95601f3793
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      server:
+      - nginx
+      date:
+      - Tue, 03 Oct 2017 17:34:55 GMT
+      content-type:
+      - application/xml;charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding
+      p3p:
+      - CP="NON"
+      x-ua-compatible:
+      - IE=Edge
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+      x-upstream:
+      - 10.0.1.39:80
+    body:
+      encoding: ASCII-8BIT
+      string: <?xml version='1.0' encoding='UTF-8'?><tsResponse xmlns="http://tableausoftware.com/api"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://tableausoftware.com/api
+        http://tableausoftware.com/api/ts-api-2.0.3.xsd"><user name="yolo.swag" fullName="Yolo
+        Swag" email="yolo.swag@shopify.com" siteRole="Interactor" /></tsResponse>
+    http_version: 
+  recorded_at: Tue, 03 Oct 2017 17:34:55 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
### What are you trying to accomplish with this PR?
To move the tableau user updater into the data portal we want to use the tableau ruby gem. When creating users we want to set their username, site role, display name, and email. To do so we need to create a user and then update that user, username and site role can be set in a create user call. This pr adds an update method and changes the create method to allow the user to specify the site role.

### How is this accomplished?
Adding a create user update method that takes in a hash with the user id and any of the attributes you want to update. Changing the create user method to allow you to set the siteRole attributes in the options hash.

### What could go wrong? (if anything)
...

### Rollback steps
- [x] It is safe to simply rollback this change. 

#### Checklist
- [x] I have tested my changes locally
- [x] I will make sure my changes pass CI before merging
- [x] I have written tests for these changes
